### PR TITLE
remove hardcoded gradle java location

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,3 @@ org.gradle.caching=true
 org.gradle.configuration-cache=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
-org.gradle.java.home=C:/Program Files/Java/jdk-21


### PR DESCRIPTION
Delete the machine-specific org.gradle.java.home entry from gradle.properties to avoid committing a local Java installation path. The android.nonTransitiveRClass setting is preserved so the file remains functional and more portable across developer environments.