### PR TITLE
Upgrade Gradle/AGP and adjust build configs

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -155,9 +155,8 @@ android {
 
     buildTypes {
         debug {
-            manifestPlaceholders += mapOf()
+            manifestPlaceholders += mapOf("appName" to "$APP_NAME-debug")
             applicationIdSuffix = ".debug"
-            manifestPlaceholders["appName"] = "$APP_NAME-debug"
 
             buildConfigField( "Boolean", "IS_AUTOUPDATE", "false" )
             signingConfig = signingConfigs.getByName("debug")
@@ -285,7 +284,8 @@ dependencies {
     implementation(libs.github.jeziellago.compose.markdown)
 
     implementation(libs.room)
-    ksp(libs.room.compiler)
+    add("kspAndroid", libs.room.compiler)
+    add("kspDesktop", libs.room.compiler)
 
     implementation(projects.innertube)
     implementation(projects.kugou)

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,9 +4,12 @@ org.gradle.parallel=true
 android.useAndroidX=true
 android.enableR8.fullMode=true
 kotlin.code.style=official
-kotlin.mpp.androidGradlePluginCompatibility.nowarn=true
-
 org.gradle.caching=true
 org.gradle.configuration-cache=true
 android.enableJetifier=false
 android.nonTransitiveRClass=true
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.builtInKotlin=false
+android.newDsl=false
+android.r8.strictFullModeForKeepRules=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 
 [versions]
 compose-plugin = "1.10.1"
-agp = "8.13.2"
+agp = "9.0.1"
 composeMarkdownVersion = "0.5.8"
 kotlin = "2.3.10"
 kotlin-ksp = "2.3.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=7197a12f450794931532469d4ff21a59ea2c1cd59a3ec3f89c035c3c420a6999
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-bin.zip
+distributionSha256Sum=72f44c9f8ebcb1af43838f45ee5c4aa9c5444898b3468ab3f4af7b6076c5bc3f
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Bump Gradle wrapper to 9.2.1 and AGP to 9.0.1, updating distribution SHA and URL. Adjust composeApp build config: set debug manifest placeholder for appName, remove duplicate assignment, and register Room KSP compiler for Android and Desktop targets (kspAndroid/kspDesktop). Update gradle.properties to enable new Gradle/AGP flags and settings required by the upgrade. These changes prepare the project for the newer Gradle/AGP behavior and KSP multiplatform configuration—verify Kotlin/KSP compatibility and run a clean build after upgrading.